### PR TITLE
Run netconf module tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actonlang/setup-acton@v1
+        with:
+          channel: 'tip'
+      - name: "Check out repository code"
+        uses: actions/checkout@v4
+      - run: acton build --dev
+      - name: "Start notconf in background"
+        run: |
+          docker run -td --name notconf --publish 42830:830 ghcr.io/notconf/notconf
+      # Only run the netconf module tests, something is broken in ssh_client ...
+      - run: acton test --module netconf

--- a/src/netconf.act
+++ b/src/netconf.act
@@ -562,7 +562,7 @@ class Buffer(object):
 # - update test_port below with the port from the above command
 # - acton test
 
-test_port = 32776
+test_port = 42830
 test_address = "localhost"
 test_username = "admin"
 test_password = "admin"
@@ -586,8 +586,8 @@ actor _test_netconf(t: testing.EnvT):
     c = Client(t.env.auth,
                 on_connect=_on_connect,
                 address=test_address,
-                username="admin",
+                username=test_username,
                 key=None,
-                password="admin",
+                password=test_password,
                 port=test_port,
                 log_handler=t.log_handler)

--- a/src/ssh_client.act
+++ b/src/ssh_client.act
@@ -184,7 +184,7 @@ actor Client(auth: WorldCap,
 # - update test_port below with the port from the above command
 # - acton test
 
-test_port = 32776
+test_port = 42830
 test_address = "localhost"
 test_username = "admin"
 test_password = "admin"
@@ -234,9 +234,9 @@ actor _test_netconf(t: testing.EnvT):
                 on_connect=_on_connect,
                 on_receive=_on_receive,
                 address=test_address,
-                username="admin",
+                username=test_username,
                 key=None,
-                password="admin",
+                password=test_password,
                 port=test_port,
                 log_handler=t.log_handler)
 
@@ -263,9 +263,9 @@ actor _test_restart(t: testing.EnvT):
                 on_connect=_on_connect,
                 on_receive=_on_receive,
                 address=test_address,
-                username="admin",
+                username=test_username,
                 key=None,
-                password="admin",
+                password=test_password,
                 port=test_port,
                 log_handler=t.log_handler)
 


### PR DESCRIPTION
Start notconf container on known port (42830) and run the network tests.
I don't know why the tests in the `ssh_client` module are failing, but the results I
get on my machine are inconsistent?!