### PR TITLE
Add Exception.msg alongside error_message

### DIFF
--- a/src/netconf.act
+++ b/src/netconf.act
@@ -387,6 +387,7 @@ class NsMaps(object):
 class IncompleteReadError(Exception):
     def __init__(self):
         self.error_message = "Not enough data to read from buffer"
+        self.msg = "Not enough data to read from buffer"
 
 class Buffer(object):
     @property


### PR DESCRIPTION
## Summary
- Add .msg attribute alongside .error_message in Exception subclasses
- This is stage 1 of the Exception.error_message -> Exception.msg migration
- Both attributes now exist and have the same value
- Stage 2 will remove .error_message in a separate PR

## Test plan
- [x] Build passes with acton build
- [x] Tests pass with acton test
- [x] No breaking changes introduced

Generated as part of the Acton ecosystem lift process.