### PR TITLE
Add lock and unlock methods to NETCONF client

### DIFF
--- a/src/netconf.act
+++ b/src/netconf.act
@@ -227,6 +227,72 @@ actor Client(auth: WorldCap, address: str, port: int, username: str, password: ?
         nc_nsdefs = [(nc_prefix, NS_NC_1_0)]
         rpc(xml.Node("discard-changes", nc_nsdefs, nc_prefix), cb)
 
+    def lock(cb: action(Client, ?NetconfError) -> None, datastore: str) -> None:
+        _log.info("NETCONF lock", {"datastore": datastore})
+
+        def _parse_response(c: Client, result: ?xml.Node):
+            error: ?NetconfError = None
+            if result is not None:
+                if result.tag == "rpc-reply":
+                    for child in result.children:
+                        if child.tag == "rpc-error":
+                            error_msg = "Lock operation failed"
+                            for error_child in child.children:
+                                if error_child.tag == "error-message" and error_child.text is not None:
+                                    error_msg = error_child.text
+                                    break
+                            error = NetconfError(error_msg)
+                            break
+                        elif child.tag == "ok":
+                            # Success case
+                            break
+                else:
+                    error = NetconfError("Unexpected response type: " + result.tag)
+            else:
+                error = NetconfError("No response received for lock operation")
+
+            cb(c, error)
+
+        nc_nsdefs = [(None, NS_NC_1_0)]
+        rpc(xml.Node("lock", nc_nsdefs, children=[
+            xml.Node("target", children=[
+                xml.Node(datastore)
+            ])
+        ]), _parse_response)
+
+    def unlock(cb: action(Client, ?NetconfError) -> None, datastore: str) -> None:
+        _log.info("NETCONF unlock", {"datastore": datastore})
+
+        def _parse_response(c: Client, result: ?xml.Node):
+            error: ?NetconfError = None
+            if result is not None:
+                if result.tag == "rpc-reply":
+                    for child in result.children:
+                        if child.tag == "rpc-error":
+                            error_msg = "Unlock operation failed"
+                            for error_child in child.children:
+                                if error_child.tag == "error-message" and error_child.text is not None:
+                                    error_msg = error_child.text
+                                    break
+                            error = NetconfError(error_msg)
+                            break
+                        elif child.tag == "ok":
+                            # Success case
+                            break
+                else:
+                    error = NetconfError("Unexpected response type: " + result.tag)
+            else:
+                error = NetconfError("No response received for unlock operation")
+
+            cb(c, error)
+
+        nc_nsdefs = [(None, NS_NC_1_0)]
+        rpc(xml.Node("unlock", nc_nsdefs, children=[
+            xml.Node("target", children=[
+                xml.Node(datastore)
+            ])
+        ]), _parse_response)
+
     def get_schema(cb: action(Client, ?xml.Node) -> None, identifier: str, version: ?str=None, format: str="yang") -> None:
         _log.info("NETCONF get-schema", {"identifier": identifier, "version": version, "format": format})
         nc_nsdefs = [(None, NS_NC_1_0)]
@@ -776,6 +842,49 @@ actor _test_list_schemas(t: testing.EnvT):
         else:
             log.warning("No schemas found")
             t.success()  # Still success even if no schemas
+
+    c = Client(t.env.auth,
+                on_connect=_on_connect,
+                on_notif=None,
+                address=test_address,
+                username=test_username,
+                key=None,
+                password=test_password,
+                port=test_port,
+                log_handler=t.log_handler)
+
+
+actor _test_lock_unlock(t: testing.EnvT):
+    """Test lock and unlock operations on a datastore
+    """
+    log = logging.Logger(t.log_handler)
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            log.error("Failed to connect", {"error": e})
+            t.failure(ValueError("Failed to connect to NETCONF server: {e}"))
+        else:
+            log.info("Connected to NETCONF server")
+            # First lock the running datastore
+            c.lock(_on_lock, "running")
+
+    def _on_lock(c: Client, error: ?NetconfError):
+        if error is not None:
+            log.error("Lock operation failed", {"error": error})
+            t.failure(ValueError("Lock operation failed: {error}"))
+        else:
+            log.info("Lock operation successful")
+            # Now unlock the datastore
+            c.unlock(_on_unlock, "running")
+
+    def _on_unlock(c: Client, error: ?NetconfError):
+        if error is not None:
+            log.error("Unlock operation failed", {"error": error})
+            t.failure(ValueError("Unlock operation failed: {error}"))
+        else:
+            log.info("Unlock operation successful")
+            log.info("Lock and unlock test completed successfully")
+            t.success()
 
     c = Client(t.env.auth,
                 on_connect=_on_connect,


### PR DESCRIPTION
Add lock() and unlock() methods to Client class for datastore locking.
We parse the XML response and map to more idiomatic Acton style with an
error argument to the callback method, set to NetconfError if anything
goes wrong.

There's a _test_lock_unlock test case to test this, which has been
tested to work against sysrepo.

Fixes #12 