### PR TITLE
Fix get-schema namespace for ietf-netconf-monitoring

### DIFF
--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -141,7 +141,15 @@ actor CmdGetSchema(env, args):
                     for child in result.children:
                         if child.tag == "rpc-error":
                             has_error = True
-                            print("  Error downloading {schema.identifier}", err=True)
+                            error_details = []
+                            for error_child in child.children:
+                                if error_child.tag == "error-message" and error_child.text is not None:
+                                    error_details.append("message: {error_child.text}")
+                                elif error_child.tag == "error-tag" and error_child.text is not None:
+                                    error_details.append("tag: {error_child.text}")
+                                elif error_child.tag == "error-type" and error_child.text is not None:
+                                    error_details.append("type: {error_child.text}")
+                            print("  Error downloading {schema.identifier}: {', '.join(error_details)}", err=True)
                             break
 
                     if not has_error:

--- a/src/netconf.act
+++ b/src/netconf.act
@@ -295,7 +295,8 @@ actor Client(auth: WorldCap, address: str, port: int, username: str, password: ?
 
     def get_schema(cb: action(Client, ?xml.Node) -> None, identifier: str, version: ?str=None, format: str="yang") -> None:
         _log.info("NETCONF get-schema", {"identifier": identifier, "version": version, "format": format})
-        nc_nsdefs = [(None, NS_NC_1_0)]
+        # get-schema is part of ietf-netconf-monitoring, not base NETCONF
+        nc_nsdefs = [(None, "urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring")]
         children = [xml.Node("identifier", text=identifier)]
         if version is not None:
             children.append(xml.Node("version", text=version))


### PR DESCRIPTION
The get-schema operation is defined in the ietf-netconf-monitoring module, not in the base NETCONF namespace. Updated the namespace to use the correct URI: urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring

Also improved error reporting in ncurl to show detailed error messages when schema downloads fail.

Fixes #15 