### PR TITLE
Fix edit-config to include XML content properly

### DIFF
--- a/src/netconf.act
+++ b/src/netconf.act
@@ -210,11 +210,22 @@ actor Client(auth: WorldCap, address: str, port: int, username: str, password: ?
     def edit_config(config: str, cb: action(Client, ?xml.Node) -> None, datastore: str="running") -> None:
         _log.info("NETCONF edit-config", {"datastore": datastore})
         nc_nsdefs = [(nc_prefix, NS_NC_1_0)]
+        # Decode the config XML string into xml.Node objects to preserve
+        # structure. Direct assignment to text attribute of the <config> node
+        # would escape special characters, breaking the XML. We wrap the config
+        # in <data> tags for parsing because there the config is likely to
+        # contain multiple top-level nodes, then use only the children.
+        # TODO: this is not very efficient as we decode the XML string to
+        # xml.Node only to encode the RPC document again right away.
+        config_xml = xml.decode("<data>{config}</data>")
         rpc(xml.Node("edit-config", nc_nsdefs, nc_prefix, children=[
             xml.Node("target", [], nc_prefix, children=[
                 xml.Node(datastore, [], nc_prefix)
             ]),
-            xml.Node("config", [], nc_prefix, text=config)
+            # Define "xc" namespace prefix for NETCONF operation attributes.
+            # Cisco IOS XRd requires namespace declaration on an ancestor node,
+            # not just where operation attributes are used.
+            xml.Node("config", [("xc", "urn:ietf:params:xml:ns:netconf:base:1.0")], nc_prefix, children=config_xml.children)
         ]), cb)
 
     def commit(cb: action(Client, ?xml.Node) -> None) -> None:


### PR DESCRIPTION
Parse config XML string to preserve structure instead of text assignment, which triggers special character encoding. This is not very efficient as we decode the XML string to xml.Node just to encode it again.

Restore explicit "xc" namespace prefix definition in <config> for NETCONF operation attributes (required by Cisco IOS XRd).

Closes #17 