### PR TITLE
Add configurable SSH host key verification

### DIFF
--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -44,6 +44,7 @@ actor CmdListSchemas(env, args, log_handler):
     port = args.get_int("port")
     username = args.get_str("username")
     password = args.get_str("password")
+    skip_host_key_check = not args.get_bool("secure")
 
     var schemas_found = []
 
@@ -86,6 +87,7 @@ actor CmdListSchemas(env, args, log_handler):
                       key=None,
                       password=password,
                       port=port,
+                      skip_host_key_check=skip_host_key_check,
                       log_handler=log_handler)
 
 
@@ -96,6 +98,7 @@ actor CmdGetConfig(env, args, log_handler):
     port = args.get_int("port")
     username = args.get_str("username")
     password = args.get_str("password")
+    skip_host_key_check = not args.get_bool("secure")
     source = args.get_str("source")
     filter_subtree = args.get_str("filter-subtree")
     filter_xpath = args.get_str("filter-xpath")
@@ -194,6 +197,7 @@ actor CmdGetConfig(env, args, log_handler):
                       key=None,
                       password=password,
                       port=port,
+                      skip_host_key_check=skip_host_key_check,
                       log_handler=log_handler)
 
 
@@ -204,6 +208,7 @@ actor CmdGetSchema(env, args, log_handler):
     port = args.get_int("port")
     username = args.get_str("username")
     password = args.get_str("password")
+    skip_host_key_check = not args.get_bool("secure")
     identifier_str = args.get_str("identifier")
     version_str = args.get_str("version")
     version = version_str if version_str != "" else None
@@ -331,6 +336,7 @@ actor CmdGetSchema(env, args, log_handler):
                   key=None,
                   password=password,
                   port=port,
+                  skip_host_key_check=skip_host_key_check,
                   log_handler=log_handler)
 
 
@@ -367,6 +373,7 @@ actor main(env):
         p.add_option("username", "str", "?", "admin", "Username for authentication")
         p.add_option("password", "str", "?", "admin", "Password for authentication")
         p.add_bool("verbose", "Verbose logging from SSH / NETCONF client")
+        p.add_bool("secure", "Enable SSH host key verification")
 
         # Commands
         p_list_schemas = p.add_cmd("list-schemas", "List available schemas", cmd_list_schemas)

--- a/src/netconf.act
+++ b/src/netconf.act
@@ -81,6 +81,7 @@ actor Client(
         key: ?str,
         on_connect: action(Client, ?Exception) -> None,
         on_notif: ?action(Client, xml.Node) -> None,
+        skip_host_key_check: bool=False,
         log_handler: ?logging.Handler):
 
     _log = logging.Logger(log_handler)
@@ -561,6 +562,7 @@ actor Client(
                               password=password,
                               port=port,
                               subsystem="netconf",
+                              skip_host_key_check=skip_host_key_check,
                               log_handler=log_handler)
 
     _connect()
@@ -811,6 +813,8 @@ actor _test_netconf(t: testing.EnvT):
                 key=None,
                 password=test_password,
                 port=test_port,
+                on_notif=None,
+                skip_host_key_check=True,
                 log_handler=t.log_handler)
 
 
@@ -846,6 +850,7 @@ actor _test_get_schema(t: testing.EnvT):
                 key=None,
                 password=test_password,
                 port=test_port,
+                skip_host_key_check=True,
                 log_handler=t.log_handler)
 
 
@@ -880,6 +885,7 @@ actor _test_list_schemas(t: testing.EnvT):
                 key=None,
                 password=test_password,
                 port=test_port,
+                skip_host_key_check=True,
                 log_handler=t.log_handler)
 
 
@@ -922,6 +928,7 @@ actor _test_lock_unlock(t: testing.EnvT):
                 key=None,
                 password=test_password,
                 port=test_port,
+                skip_host_key_check=True,
                 log_handler=t.log_handler)
 
 
@@ -998,6 +1005,7 @@ actor _test_get_config_with_filter(t: testing.EnvT):
                 key=None,
                 password=test_password,
                 port=test_port,
+                skip_host_key_check=True,
                 log_handler=t.log_handler)
 
 
@@ -1065,6 +1073,7 @@ actor _test_get_config_with_xpath_filter(t: testing.EnvT):
                 key=None,
                 password=test_password,
                 port=test_port,
+                skip_host_key_check=True,
                 log_handler=t.log_handler)
 
 

--- a/src/ssh_client.act
+++ b/src/ssh_client.act
@@ -45,6 +45,7 @@ actor Client(auth: WorldCap,
              password: ?str,
              port: int=22,
              subsystem: ?str=None,
+             skip_host_key_check: bool=False,
              log_handler: ?logging.Handler=None):
     _log = logging.Logger(log_handler)
     _log.info("Connecting", {"address": address, "username": username, "port": port})
@@ -151,8 +152,10 @@ actor Client(auth: WorldCap,
         cmd_env = None
         # Use -v for verbose output, we need this to determine e.g. connection established
         cmd = ["ssh", "-v", "-p", str(port), "-l", username]
-        # TODO: do something better than accepting all new host keys!
-        cmd += ["-o", "StrictHostKeyChecking=no"]  # Disable strict host key checking
+        if skip_host_key_check:
+            # Skip host key checking for testing environments
+            cmd += ["-o", "StrictHostKeyChecking=no"]  # Disable strict host key checking
+            cmd += ["-o", "UserKnownHostsFile=/dev/null"]  # Don't use known_hosts file
         if key is not None:
             cmd += ["-i", key]
         elif password is not None:
@@ -211,6 +214,7 @@ actor _test_bad_credentials(t: testing.EnvT):
                 key=None,
                 password="dummy",
                 port=test_port,
+                skip_host_key_check=True,
                 log_handler=t.log_handler)
 
 actor _test_netconf(t: testing.EnvT):
@@ -238,6 +242,7 @@ actor _test_netconf(t: testing.EnvT):
                 key=None,
                 password=test_password,
                 port=test_port,
+                skip_host_key_check=True,
                 log_handler=t.log_handler)
 
 actor _test_restart(t: testing.EnvT):
@@ -267,6 +272,7 @@ actor _test_restart(t: testing.EnvT):
                 key=None,
                 password=test_password,
                 port=test_port,
+                skip_host_key_check=True,
                 log_handler=t.log_handler)
 
 
@@ -302,4 +308,5 @@ actor client(env: Env):
                 key=None,
                 password=test_password,
                 port=test_port,
+                skip_host_key_check=True,
                 log_handler=log_handler)


### PR DESCRIPTION
Introduces skip_host_key_check parameter NETCONF, SSH Client actors to control SSH host key verification. Default behavior is secure (verification enabled) at the library level. This makes security decisions explicit in code to prevent accidental misuse. When enabled, sets StrictHostKeyChecking=no and UserKnownHostsFile=/dev/null SSH options.

Add --secure flag to ncurl with inverted logic for testing convenience. Also update test cases to use skip_host_key_check=True for container environments.