### PR TITLE
Use serial RPC matching mode

### DIFF
--- a/src/netconf.act
+++ b/src/netconf.act
@@ -193,7 +193,7 @@ actor Client(
     var nc_prefix: ?str = None
 
     var message_id = 1
-    var rpc_cbs: dict[str, action(Client, ?xml.Node, ?NetconfError) -> None] = {}
+    var rpc_cbs: list[(id: str, cb: action(Client, ?xml.Node, ?NetconfError) -> None)] = []
 
     var c: ?ssh_client.Client = None
     var state = STATE_NONE
@@ -222,10 +222,9 @@ actor Client(
 
     # TODO: Close protocol
     def close(cb: ?action() -> None) -> None:
-        for rpc_cb in rpc_cbs.values():
-            rpc_cb(self, None, None)
-        #rpc_cbs.clear()
-        rpc_cbs = {}
+        for rpc_cb in rpc_cbs:
+            rpc_cb.cb(self, None, None)
+        rpc_cbs.clear()
 
         if c is not None:
             c.close(cb)
@@ -236,8 +235,8 @@ actor Client(
     # TODO: Restart protocol
     def restart() -> None:
         _log.info("Restarting")
-        for rpc_cb in rpc_cbs.values():
-            rpc_cb(self, None, None)
+        for rpc_cb in rpc_cbs:
+            rpc_cb.cb(self, None, None)
 
         framing = SEPARATOR_FRAMING
         recv_buf = Buffer()
@@ -247,7 +246,7 @@ actor Client(
         capabilities = []
 
         message_id = 1
-        rpc_cbs = {}
+        rpc_cbs.clear()
 
         state = STATE_NONE
 
@@ -284,16 +283,16 @@ actor Client(
         # If using an explicit namespace prefix, prepend it to the attribute name.
         # The namespace (prefix or not) is defined in the tag.
         if nc_prefix is not None:
-            rpc_attrs = [(nc_prefix + ":message-id", str(message_id_text))]
+            rpc_attrs = [(nc_prefix + ":message-id", message_id_text)]
         else:
-            rpc_attrs = [("message-id", str(message_id_text))]
+            rpc_attrs = [("message-id", message_id_text)]
 
         root = xml.Node("rpc", [(nc_prefix, NS_NC_1_0)], nc_prefix, rpc_attrs, [content])
 
         buf: Buffer = Buffer()
         buf.write_str(xml.encode(root))
 
-        rpc_cbs[message_id_text] = callback
+        rpc_cbs.append((id=message_id_text, cb=callback))
         _log.debug("Sending RPC", {"message-id": message_id_text, "content": content})
         _send_message(buf)
 
@@ -510,30 +509,32 @@ actor Client(
                 msg_id = attr_val
                 break
 
-        if msg_id is not None:
-            _cb = rpc_cbs.pop(msg_id)
-            if _cb is not None:
-                _log.debug("Received rpc-reply", {"msg-id": msg_id})
+        if len(rpc_cbs) > 0:
+            cb = rpc_cbs.pop(0)
+            if msg_id is None:
+                _log.warning("Received invalid rpc-reply, missing message-id", {"msg": root.encode()})
+            elif msg_id is not None and msg_id != cb.id:
+                _log.warning("Received rpc-reply with unexpected message-id", {"msg-id": msg_id, "cb.id": cb.id})
 
-                if len(root.children) == 0:
-                    _cb(self, root, NetconfError("Empty <rpc-reply>"))
-                elif len(root.children) == 1 and root.children[0].tag == "ok":
-                    # TODO: Should also verify namespace is NS_NC_1_0
-                    _cb(self, root, None)
-                else:
-                    # Parse for errors
-                    error = _parse_rpc_errors(root)
-
-                    if error is not None:
-                        # Error response
-                        _cb(self, root, error)
-                    else:
-                        # Normal data response - pass the whole root
-                        _cb(self, root, None)
+            if len(root.children) == 0:
+                cb.cb(self, root, NetconfError("Empty <rpc-reply>"))
+            elif len(root.children) == 1 and root.children[0].tag == "ok":
+                # TODO: Should also verify namespace is NS_NC_1_0
+                cb.cb(self, root, None)
             else:
-                _log.debug("Received rpc-reply with unexpected message-id", {"msg-id": msg_id})
+                # Parse for errors
+                error = _parse_rpc_errors(root)
+
+                if error is not None:
+                    # Error response
+                    cb.cb(self, root, error)
+                else:
+                    # Normal data response - pass the whole root
+                    cb.cb(self, root, None)
         else:
-            _log.debug("Received rpc-reply without message-id", None)
+            _log.error("No more RPC callbacks", {"msg-id": msg_id})
+
+
 
     def _on_msg_notification(root: xml.Node) -> None:
         _on_notif = on_notif


### PR DESCRIPTION
This switches over the algorithm for matching rpc-replies with a callback to the simple assumption of strict serialization in NETCONF.

NETCONF requires that RPC messages have a message-id set and NETCONF servers are supposed to return the message-id, or really any XML attribute set in the RPC message. We've relied on message-id for matching up and finding the callback functions for RPC-replies. While fairly simple and robust, it's turned out that some NETCONF servers manage to mess up the message-id. We now switch over to assuming that the callbacks are in order in the list of callbacks. Since NETCONF guarantees strict sequence for messages, this should be fine. Hard to say if there might be other quirks that breaks this - we will have to see.