### PR TITLE
Wait for notconf health

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,25 @@ jobs:
       - name: "Start notconf in background"
         run: |
           docker run -td --name notconf --publish 42830:830 ghcr.io/notconf/notconf
+      - name: "Wait for notconf"
+        run: |
+          for i in {1..30}; do
+            status="$(docker inspect --format '{{.State.Health.Status}}' notconf)"
+            echo "notconf health: ${status}"
+
+            if [ "${status}" = "healthy" ]; then
+              exit 0
+            fi
+
+            if [ "${status}" = "unhealthy" ]; then
+              docker logs notconf
+              exit 1
+            fi
+
+            sleep 1
+          done
+
+          docker logs notconf
+          exit 1
       # notconf is stateful and module tests are sensitive to parallel/retry runs
       - run: acton test --tag notconf-server --module netconf --jobs 1 --min-iter 1 --max-iter 1


### PR DESCRIPTION
The tagged NETCONF tests were racing the notconf container startup after `docker run -d`. The current image can publish the SSH port before the NETCONF SSH server is ready, which leaves early client sessions failing during SSH key exchange.

This adds a workflow readiness gate that waits for Docker's notconf health check before running the tagged tests, and prints container logs if readiness fails.